### PR TITLE
Upgrade Kotlin/Gradle/dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'digital.wup:android-maven-publish:3.4.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'digital.wup:android-maven-publish:3.6.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Package
-packageVersion         = 3.4.1
+packageVersion         = 3.5.0
 mirukenGroupId         = com.miruken
 mirukenOrg             = miruken
 mirukenRepo            = MavenPackages
@@ -7,7 +7,7 @@ mirukenVcsUrl          = https://github.com/Miruken-Kotlin
 mirukenLicense         = MIT
 
 # Denpendencies
-kotlinVersion          = 1.3.50
+kotlinVersion          = 1.3.61
 mirukenVersion         = 3.0.0
 
 # Android

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/miruken-gradle-android/build.gradle
+++ b/miruken-gradle-android/build.gradle
@@ -18,9 +18,9 @@ gradlePlugin {
 
 dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-    implementation 'com.android.tools.build:gradle:3.3.2'
-    implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.30'
-    implementation 'io.github.classgraph:classgraph:4.8.26'
+    implementation 'com.android.tools.build:gradle:3.5.3'
+    implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61'
+    implementation 'io.github.classgraph:classgraph:4.8.65'
 }
 
 def artifactName = 'miruken-gradle-android'

--- a/miruken-gradle-android/src/main/kotlin/com/miruken/FindMirukenHandlersTask.kt
+++ b/miruken-gradle-android/src/main/kotlin/com/miruken/FindMirukenHandlersTask.kt
@@ -1,5 +1,6 @@
 package com.miruken
 
+import com.android.build.gradle.internal.tasks.factory.dependsOn
 import org.gradle.api.DefaultTask
 import java.io.File
 import io.github.classgraph.ClassGraph
@@ -43,17 +44,17 @@ open class FindMirukenHandlersTask : DefaultTask() {
                     studioBuild   = false
                 }
                 else -> {
-                    //Can't get rid of this deprecated call until we can go to gradle 4.10
-                    //digital.wup:android-maven-publish:3.4.0 has us stuck on 4.6
-                    variant.mergeAssets.also{ p ->
-                        val output = "${p.outputDir}/com/miruken/"
+                    variant.mergeAssetsProvider.also{ p ->
+                        val mergeSourceSetFolders = p.get()
+
+                        val output = "${mergeSourceSetFolders.outputDir.get()}/com/miruken/"
                         p.dependsOn(this)
-                        p.doLast {
+                        mergeSourceSetFolders.doLast {
                             val dir = "$output${project.name}/"
                             File(scanResult).copyTo(File("$dir/$fileName"), true)
                         }
                         if (project.isApplication) {
-                            p.doLast {
+                            mergeSourceSetFolders.doLast {
                                 val handlers = File("$output$fileName")
                                 if (handlers.exists()) {
                                     handlers.delete()

--- a/miruken-mvc-android/build.gradle
+++ b/miruken-mvc-android/build.gradle
@@ -39,10 +39,11 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api "com.miruken:miruken:$mirukenVersion"
     api "com.miruken:miruken-mvc:$mirukenVersion"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0'
     implementation 'com.jakewharton.timber:timber:4.7.1'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.3.61'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'


### PR DESCRIPTION
This updates the Kotlin language version, Gradle plugin version, and other dependency versions in order to remove the deprecated call to `getMergeAssets()`.